### PR TITLE
Indentation of manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,5 +11,5 @@
     "permissions": [
         "activeTab",
         "https://ajax.googleapis.com/"
-        ]
+    ]
 }


### PR DESCRIPTION
Encouraging proper indentation of JSON-files.
